### PR TITLE
deps: Loosen requests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.24.0
+requests~=2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.24.0
+requests>=2.24.0,<3.0


### PR DESCRIPTION

## Changes

I had an issue installing the package in a poetry project because of the pinned version of requests. 

```
Because ordway (0.5.2) @ git+https://github.com/iconik-io/ordway.git@iconik_ordway_changes depends on requests (2.24.0)
 and accounts-api depends on requests (^2.28.2), ordway is forbidden.
So, because accounts-api depends on ordway (0.5.2) @ git+https://github.com/iconik-io/ordway.git@iconik_ordway_changes, version solving failed.
```

Loosening that version to be semver-compatible instead.